### PR TITLE
Enable to fail if clippy warnings exist

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,9 +18,9 @@ jobs:
           toolchain: stable
           components: clippy
           override: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clippy check
+        # `bindgen` generated code makes some errors so allow these lints for now.
+        run: cargo clippy -- -D warnings -A clippy::upper-case-acronyms -A clippy::derive-partial-eq-without-eq
 
   grcov:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- #9 and #10 have some clippy warnings but CI wouldn't fail
    - https://github.com/QunaSys/qurs/runs/7785708664?check_suite_focus=true#step:4:217
- Use `-D warnings` option for clippy, we make CI fail if the code has any warnings
- Drop `actions-rs/clippy-check` because it seems to hasn't been maintained yet 😇 
    - https://github.com/actions-rs/clippy-check/issues/162